### PR TITLE
Use lambda instead of unhygienic var in projection macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ The `project/2` macro expects the domain event and metadata. You can also use `p
 defmodule MyApp.ExampleProjector do
   use Commanded.Projections.Ecto, name: "example_projection"
 
-  project %AnEvent{name: name}, _metadata do
+  project %AnEvent{name: name}, _metadata, fn multi ->
     Ecto.Multi.insert(multi, :example_projection, %ExampleProjection{name: name})
   end
 
-  project %AnotherEvent{name: name} do
+  project %AnotherEvent{name: name}, fn multi ->
     Ecto.Multi.insert(multi, :example_projection, %ExampleProjection{name: name})
   end
 end
@@ -143,7 +143,7 @@ end
 If you want to skip a projection event, you can return the `multi` transaction without further modifying it:
 
 ```elixir
-project %ItemUpdated{uuid: uuid} = event, _metadata do
+project %ItemUpdated{uuid: uuid} = event, _metadata, fn multi ->
   case Repo.get(ItemProjection, uuid) do
     nil -> multi
     item -> Ecto.Multi.update(multi, :item, update_changeset(event, item))
@@ -200,7 +200,7 @@ defmodule MyApp.ExampleProjector do
 
   alias Commanded.Event.FailureContext
 
-  project %AnEvent{} do
+  project %AnEvent{}, fn _multi ->
     {:error, :failed}
   end
 
@@ -227,7 +227,7 @@ You can define an `after_update/3` function in a projector to be called after ea
 defmodule MyApp.ExampleProjector do
   use Commanded.Projections.Ecto, name: "MyApp.ExampleProjector"
 
-  project %AnEvent{name: name} do
+  project %AnEvent{name: name}, fn multi ->
     Ecto.Multi.insert(multi, :example_projection, %ExampleProjection{name: name})
   end
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ end
 
 For each read model you will need to define a module that uses the `Commanded.Projections.Ecto` macro and configures the domain events to be projected. The `:name` option passed to the `use` invocation specifies the name of the subscription to be used. It can be any string that is unique among subscriptions.
 
-The `project/2` macro expects the domain event and metadata. You can also use `project/1` if you do not need to use the event metadata. Inside the project block you have access to an [Ecto.Multi](https://hexdocs.pm/ecto/Ecto.Multi.html) data structure, available as the `multi` variable, for grouping multiple Repo operations. These will all be executed within a single transaction. You can use `Ecto.Multi` to insert, update, and delete data.
+The `project/3` macro expects the domain event, metadata and function that takes and returns an [Ecto.Multi](https://hexdocs.pm/ecto/Ecto.Multi.html) data structure for grouping multiple Repo operations. These will all be executed within a single transaction. You can use `Ecto.Multi` to insert, update, and delete data.
+
+You can also use `project/2` if you do not need to use the event metadata.
 
 ```elixir
 defmodule MyApp.ExampleProjector do

--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -11,11 +11,11 @@ defmodule Commanded.Projections.Ecto do
           schema_prefix: "my-prefix",
           timeout: :infinity
 
-        project %Event{}, _metadata do
+        project %Event{}, _metadata, fn multi ->
           Ecto.Multi.insert(multi, :my_projection, %MyProjection{...})
         end
 
-        project %AnotherEvent{} do
+        project %AnotherEvent{}, fn multi ->
           Ecto.Multi.insert(multi, :my_projection, %MyProjection{...})
         end
       end
@@ -142,21 +142,21 @@ defmodule Commanded.Projections.Ecto do
     end
   end
 
-  defmacro project(event, metadata, do: block) do
+  defmacro project(event, metadata, lambda) do
     quote do
       def handle(unquote(event) = event, unquote(metadata) = metadata) do
-        update_projection(event, metadata, fn var!(multi) ->
-          unquote(block)
+        update_projection(event, metadata, fn multi ->
+          unquote(lambda).(multi)
         end)
       end
     end
   end
 
-  defmacro project(event, do: block) do
+  defmacro project(event, lambda) do
     quote do
       def handle(unquote(event) = event, metadata) do
-        update_projection(event, metadata, fn var!(multi) ->
-          unquote(block)
+        update_projection(event, metadata, fn multi ->
+          unquote(lambda).(multi)
         end)
       end
     end

--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -142,11 +142,41 @@ defmodule Commanded.Projections.Ecto do
     end
   end
 
+  defmacro project(event, metadata, do: block) do
+    IO.warn(
+      "project macro with \"do end\" block is deprecated; use project/3 with function instead",
+      Macro.Env.stacktrace(__ENV__)
+    )
+
+    quote do
+      def handle(unquote(event) = event, unquote(metadata) = metadata) do
+        update_projection(event, metadata, fn var!(multi) ->
+          unquote(block)
+        end)
+      end
+    end
+  end
+
   defmacro project(event, metadata, lambda) do
     quote do
       def handle(unquote(event) = event, unquote(metadata) = metadata) do
         update_projection(event, metadata, fn multi ->
           unquote(lambda).(multi)
+        end)
+      end
+    end
+  end
+
+  defmacro project(event, do: block) do
+    IO.warn(
+      "project macro with \"do end\" block is deprecated; use project/2 with function instead",
+      Macro.Env.stacktrace(__ENV__)
+    )
+
+    quote do
+      def handle(unquote(event) = event, metadata) do
+        update_projection(event, metadata, fn var!(multi) ->
+          unquote(block)
         end)
       end
     end

--- a/test/projections/after_update_callback_test.exs
+++ b/test/projections/after_update_callback_test.exs
@@ -19,7 +19,7 @@ defmodule Commanded.Projections.AfterUpdateCallbackTest do
   defmodule Projector do
     use Commanded.Projections.Ecto, name: "projection"
 
-    project %AnEvent{name: name} do
+    project %AnEvent{name: name}, fn multi ->
       Ecto.Multi.insert(multi, :my_projection, %Projection{name: name})
     end
 

--- a/test/projections/ecto_test.exs
+++ b/test/projections/ecto_test.exs
@@ -21,15 +21,15 @@ defmodule Commanded.Projections.EctoTest do
   defmodule Projector do
     use Commanded.Projections.Ecto, name: "Projector"
 
-    project %AnEvent{name: name}, _metadata do
+    project %AnEvent{name: name}, _metadata, fn multi ->
       Ecto.Multi.insert(multi, :my_projection, %Projection{name: name})
     end
 
-    project %AnotherEvent{name: name} do
+    project %AnotherEvent{name: name}, fn multi ->
       Ecto.Multi.insert(multi, :my_projection, %Projection{name: name})
     end
 
-    project %ErrorEvent{} do
+    project %ErrorEvent{}, fn multi ->
       Ecto.Multi.error(multi, :my_projection, :failure)
     end
   end

--- a/test/projections/error_callback_test.exs
+++ b/test/projections/error_callback_test.exs
@@ -34,24 +34,24 @@ defmodule Commanded.Projections.ErrorCallbackTest do
   defmodule ErrorProjector do
     use Commanded.Projections.Ecto, name: "ErrorProjector"
 
-    project %AnEvent{name: name, pid: pid} = event do
+    project %AnEvent{name: name, pid: pid} = event, fn multi ->
       send(pid, event)
 
       Ecto.Multi.insert(multi, :projection, %Projection{name: name})
     end
 
-    project %ErrorEvent{name: name} do
+    project %ErrorEvent{name: name}, fn multi ->
       Ecto.Multi.insert(multi, :projection, %Projection{name: name})
 
       {:error, :failed}
     end
 
-    project %ExceptionEvent{} do
+    project %ExceptionEvent{}, fn multi ->
       # Attempt an invalid insert due to `name` type mismatch (expects a string).
       Ecto.Multi.insert(multi, :projection, %Projection{name: 1})
     end
 
-    project %InvalidMultiEvent{name: name} do
+    project %InvalidMultiEvent{name: name}, fn multi ->
       # Attempt to execute an invalid Ecto query (comparison with `nil` is forbidden as it is unsafe).
       query = from(p in Projection, where: p.name == ^name)
 

--- a/test/projections/projection_version_schema_prefix_test.exs
+++ b/test/projections/projection_version_schema_prefix_test.exs
@@ -57,7 +57,7 @@ defmodule Commanded.Projections.ProjectionVersionSchemaPrefixTest do
         name: "test-projector",
         schema_prefix: "test"
 
-      project(%AnEvent{}, do: multi)
+      project(%AnEvent{}, & &1)
     end
 
     alias TestPrefixProjector.ProjectionVersion


### PR DESCRIPTION
Attempt to solve #8 

I wasn't sure if you want to keep older, more "magical" version of macro or do breaking change. Both versions can exist at the same time, because `do end` block have different pattern to match. Let me know if you want me to readd older version of macro and double tests count.