### PR TITLE
fixed changeset dialyzer warnings

### DIFF
--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -135,7 +135,7 @@ defmodule Commanded.Projections.Ecto do
 
         @required_fields ~w(last_seen_event_number)
 
-        def changeset(model, params \\ :empty) do
+        def changeset(model, params \\ :invalid) do
           cast(model, params, @required_fields)
         end
       end


### PR DESCRIPTION
This fixes following dialyzer warnings:
```
lib/my_app/projector.ex:2:no_return
Function changeset/1 has no local return.
________________________________________________________________________________
lib/my_app/projector.ex:2:call
The call:
MyApp.Projector.ProjectionVersion.changeset(_any(), :empty)

will never return since it differs in arguments with
positions 2 from the success typing arguments:

(
  {map(), map()} | %{:__struct__ => atom(), atom() => _},
  :invalid | %{:__struct__ => none(), (atom() | binary()) => _}
)

```
Reason:
> The :empty atom in cast(source, :empty, required, optional) has been deprecated, please use an empty map or :invalid instead

from [Ecto v2.0 changelog](https://github.com/elixir-ecto/ecto/blob/v2.0/CHANGELOG.md)