### PR TITLE
add .formatter.exs to hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -71,6 +71,7 @@ defmodule Commanded.Projections.Ecto.Mixfile do
       files: [
         "lib",
         "mix.exs",
+        ".formatter.exs",
         "README*",
         "LICENSE*",
         "priv/repo/migrations"


### PR DESCRIPTION
it's required for dependent projects to import locals_without_parens