### PR TITLE
Use `timestamp with time zone` for timestamp fields in `projection_versions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Upgrading
+
+- Upgrade your existing `projection_versions` table by running:
+
+  ```sql
+  ALTER TABLE projection_versions ALTER COLUMN inserted_at TYPE timestamp with time zone USING inserted_at AT TIME ZONE 'UTC';
+  ALTER TABLE projection_versions ALTER COLUMN updated_at TYPE timestamp with time zone USING updated_at AT TIME ZONE 'UTC';
+  ```
+
 ## 1.4.0
 
 ### Enhancements

--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -211,7 +211,7 @@ defmodule Commanded.Projections.Ecto do
         schema "projection_versions" do
           field(:last_seen_event_number, :integer)
 
-          timestamps(type: :naive_datetime_usec)
+          timestamps(type: :utc_datetime_usec)
         end
       end
     end

--- a/priv/repo/migrations/20170609113553_create_projection_versions.exs
+++ b/priv/repo/migrations/20170609113553_create_projection_versions.exs
@@ -6,7 +6,7 @@ defmodule Commanded.Projections.Repo.Migrations.CreateProjectionVersions do
       add(:projection_name, :text, primary_key: true)
       add(:last_seen_event_number, :bigint)
 
-      timestamps(type: :naive_datetime_usec)
+      timestamps(type: :timestamptz)
     end
   end
 end

--- a/priv/repo/migrations/20170929080308_create_projection_version_with_prefix.exs
+++ b/priv/repo/migrations/20170929080308_create_projection_version_with_prefix.exs
@@ -8,7 +8,7 @@ defmodule Commanded.Projections.Repo.Migrations.CreateProjectionVersionWithPrefi
       add(:projection_name, :text, primary_key: true)
       add(:last_seen_event_number, :bigint)
 
-      timestamps(type: :naive_datetime_usec)
+      timestamps(type: :timestamptz)
     end
   end
 


### PR DESCRIPTION
Fixes #20.