### PR TITLE
Support runtime projector names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+- Support runtime projector names ([#32](https://github.com/commanded/commanded-ecto-projections/pull/32)).
+
+---
+
 ## v1.1.0
 
 ### Enhancements

--- a/guides/Usage.md
+++ b/guides/Usage.md
@@ -2,7 +2,7 @@
 
 ## Creating a read model
 
-Use Ecto schemas to define your read model:
+Use `Ecto.Schema` to define one or more read models:
 
 ```elixir
 defmodule ExampleProjection do
@@ -20,7 +20,7 @@ For each read model you will need to define a module that uses the `Commanded.Pr
 
 You must specify the following options when defining an Ecto projector:
 
-- `:application` - (module) the Commanded application (e.g. `MyApp.Application`).
+- `:application` - (module or atom) the Commanded application (e.g. `MyApp.Application`).
 - `:repo` - (module) an Ecto repo (e.g. `MyApp.Projections.Repo`).
 - `:name` - (string) a unique name used to identify the event store subscription used by the projector.
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Commanded.Projections.Ecto.Mixfile do
 
   defp deps do
     [
-      {:commanded, "~> 1.1"},
+      {:commanded, github: "commanded/commanded"},
       {:ecto, "~> 3.4"},
       {:ecto_sql, "~> 3.4"},
       {:postgrex, ">= 0.0.0", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Commanded.Projections.Ecto.Mixfile do
 
   defp deps do
     [
-      {:commanded, github: "commanded/commanded"},
+      {:commanded, "~> 1.2"},
       {:ecto, "~> 3.4"},
       {:ecto_sql, "~> 3.4"},
       {:postgrex, ">= 0.0.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm", "cf0cfff8995fb20562f822e5cc47d8ccf664c5ecdc26a684cbe85c225f9d7c39"},
-  "commanded": {:git, "https://github.com/commanded/commanded.git", "638c3b6d4fc4a725c74d639f62e4b60f05051fc4", []},
+  "commanded": {:hex, :commanded, "1.2.0", "d0c604e885132cbca875c238b741e0e2059c54395b4087d3d91763ebf06254d2", [:mix], [{:backoff, "~> 1.1", [hex: :backoff, repo: "hexpm", optional: false]}, {:elixir_uuid, "~> 1.2", [hex: :elixir_uuid, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 2.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: true]}], "hexpm", "64e51d04773d0b74568ea1d0886c57e350139438096992ad3456d9d80363d0b5"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
   "db_connection": {:hex, :db_connection, "2.2.2", "3bbca41b199e1598245b716248964926303b5d4609ff065125ce98bcd368939e", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm", "642af240d8a8affb93b4ba5a6fcd2bbcbdc327e1a524b825d383711536f8070c"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm", "3cb154b00225ac687f6cbd4acc4b7960027c757a5152b369923ead9ddbca7aec"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm", "cf0cfff8995fb20562f822e5cc47d8ccf664c5ecdc26a684cbe85c225f9d7c39"},
-  "commanded": {:hex, :commanded, "1.1.1", "0464d7fd30314b595e29229f927f38308698a10bb4106e5bf34b332dd6ff65ad", [:mix], [{:backoff, "~> 1.1", [hex: :backoff, repo: "hexpm", optional: false]}, {:elixir_uuid, "~> 1.2", [hex: :elixir_uuid, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 2.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: true]}], "hexpm", "4a956f47818d9f8c99fd0db2a941290311195210a6c7529b088a497e9d14f0f7"},
+  "commanded": {:git, "https://github.com/commanded/commanded.git", "638c3b6d4fc4a725c74d639f62e4b60f05051fc4", []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
   "db_connection": {:hex, :db_connection, "2.2.2", "3bbca41b199e1598245b716248964926303b5d4609ff065125ce98bcd368939e", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm", "642af240d8a8affb93b4ba5a6fcd2bbcbdc327e1a524b825d383711536f8070c"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm", "3cb154b00225ac687f6cbd4acc4b7960027c757a5152b369923ead9ddbca7aec"},

--- a/test/projections/deprecated_projection_test.exs
+++ b/test/projections/deprecated_projection_test.exs
@@ -5,18 +5,8 @@ defmodule Commanded.Projections.DeprecatedProjectionTest do
   import ExUnit.CaptureIO
 
   alias Commanded.Projections.Repo
-
-  defmodule AnEvent do
-    defstruct name: "AnEvent"
-  end
-
-  defmodule Projection do
-    use Ecto.Schema
-
-    schema "projections" do
-      field(:name, :string)
-    end
-  end
+  alias Commanded.Projections.Events.AnEvent
+  alias Commanded.Projections.Projection
 
   setup do
     start_supervised!(TestApplication)
@@ -33,7 +23,11 @@ defmodule Commanded.Projections.DeprecatedProjectionTest do
         end
       end
 
-      assert :ok == DeprecatedProjector.handle(%AnEvent{}, %{event_number: 1})
+      assert :ok ==
+               DeprecatedProjector.handle(%AnEvent{}, %{
+                 handler_name: "DeprecatedProjector",
+                 event_number: 1
+               })
 
       assert_projections(Projection, ["AnEvent"])
       assert_seen_event("DeprecatedProjector", 1)

--- a/test/projections/ecto_projection_test.exs
+++ b/test/projections/ecto_projection_test.exs
@@ -3,31 +3,9 @@ defmodule Commanded.Projections.EctoProjectionTest do
 
   import Commanded.Projections.ProjectionAssertions
 
+  alias Commanded.Projections.Events.{AnEvent, AnotherEvent, ErrorEvent, IgnoredEvent}
+  alias Commanded.Projections.Projection
   alias Commanded.Projections.Repo
-
-  defmodule AnEvent do
-    defstruct name: "AnEvent"
-  end
-
-  defmodule AnotherEvent do
-    defstruct name: "AnotherEvent"
-  end
-
-  defmodule IgnoredEvent do
-    defstruct name: "IgnoredEvent"
-  end
-
-  defmodule ErrorEvent do
-    defstruct name: "ErrorEvent"
-  end
-
-  defmodule Projection do
-    use Ecto.Schema
-
-    schema "projections" do
-      field(:name, :string)
-    end
-  end
 
   defmodule Projector do
     use Commanded.Projections.Ecto, application: TestApplication, name: "Projector"
@@ -51,24 +29,24 @@ defmodule Commanded.Projections.EctoProjectionTest do
   end
 
   test "should handle a projected event" do
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
 
     assert_projections(Projection, ["AnEvent"])
     assert_seen_event("Projector", 1)
   end
 
   test "should handle two different types of projected events" do
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
-    assert :ok == Projector.handle(%AnotherEvent{}, %{event_number: 2})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
+    assert :ok == Projector.handle(%AnotherEvent{}, %{handler_name: "Projector", event_number: 2})
 
     assert_projections(Projection, ["AnEvent", "AnotherEvent"])
     assert_seen_event("Projector", 2)
   end
 
   test "should ignore already projected event" do
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
 
     assert_projections(Projection, ["AnEvent"])
     assert_seen_event("Projector", 1)
@@ -81,17 +59,18 @@ defmodule Commanded.Projections.EctoProjectionTest do
   end
 
   test "should ignore unprojected events amongst projections" do
-    assert :ok == Projector.handle(%AnEvent{}, %{event_number: 1})
-    assert :ok == Projector.handle(%IgnoredEvent{}, %{event_number: 2})
-    assert :ok == Projector.handle(%AnotherEvent{}, %{event_number: 3})
-    assert :ok == Projector.handle(%IgnoredEvent{}, %{event_number: 4})
+    assert :ok == Projector.handle(%AnEvent{}, %{handler_name: "Projector", event_number: 1})
+    assert :ok == Projector.handle(%IgnoredEvent{}, %{handler_name: "Projector", event_number: 2})
+    assert :ok == Projector.handle(%AnotherEvent{}, %{handler_name: "Projector", event_number: 3})
+    assert :ok == Projector.handle(%IgnoredEvent{}, %{handler_name: "Projector", event_number: 4})
 
     assert_projections(Projection, ["AnEvent", "AnotherEvent"])
     assert_seen_event("Projector", 3)
   end
 
   test "should return an error on failure" do
-    assert {:error, :failure} == Projector.handle(%ErrorEvent{}, %{event_number: 1})
+    assert {:error, :failure} ==
+             Projector.handle(%ErrorEvent{}, %{handler_name: "Projector", event_number: 1})
 
     assert_projections(Projection, [])
   end
@@ -135,13 +114,16 @@ defmodule Commanded.Projections.EctoProjectionTest do
     end
   end
 
-  test "should ensure projection name is present" do
-    assert_raise RuntimeError, "UnnamedProjector expects :name to be given", fn ->
-      Code.eval_string("""
-      defmodule UnnamedProjector do
-        use Commanded.Projections.Ecto, application: TestApplication
-      end
-      """)
+  defmodule UnnamedProjector do
+    use Commanded.Projections.Ecto, application: TestApplication
+  end
+
+  test "should ensure projection name is present on start" do
+    expected_error =
+      "Commanded.Projections.EctoProjectionTest.UnnamedProjector expects :name option"
+
+    assert_raise ArgumentError, expected_error, fn ->
+      UnnamedProjector.start_link()
     end
   end
 end

--- a/test/projections/error_callback_test.exs
+++ b/test/projections/error_callback_test.exs
@@ -5,31 +5,9 @@ defmodule Commanded.Projections.ErrorCallbackTest do
 
   alias Commanded.Event.FailureContext
   alias Commanded.EventStore.RecordedEvent
+  alias Commanded.Projections.Events.{AnEvent, ErrorEvent, ExceptionEvent, InvalidMultiEvent}
+  alias Commanded.Projections.Projection
   alias Commanded.Projections.Repo
-
-  defmodule AnEvent do
-    defstruct [:pid, name: "AnEvent"]
-  end
-
-  defmodule ErrorEvent do
-    defstruct [:pid, name: "ErrorEvent"]
-  end
-
-  defmodule ExceptionEvent do
-    defstruct [:pid, name: "ExceptionEvent"]
-  end
-
-  defmodule InvalidMultiEvent do
-    defstruct [:pid, :name]
-  end
-
-  defmodule Projection do
-    use Ecto.Schema
-
-    schema "projections" do
-      field(:name, :string)
-    end
-  end
 
   defmodule ErrorProjector do
     use Commanded.Projections.Ecto, application: TestApplication, name: "ErrorProjector"
@@ -84,7 +62,7 @@ defmodule Commanded.Projections.ErrorCallbackTest do
 
   test "should allow returning an error tagged tuple from `project` macro" do
     event = %ErrorEvent{pid: self()}
-    metadata = %{event_number: 1}
+    metadata = %{handler_name: "ErrorProjector", event_number: 1}
 
     assert {:error, :failed} == ErrorProjector.handle(event, metadata)
   end

--- a/test/projections/runtime_config_projector_test.exs
+++ b/test/projections/runtime_config_projector_test.exs
@@ -1,0 +1,56 @@
+defmodule Commanded.Projections.RuntimeConfigProjectorTest do
+  use ExUnit.Case
+
+  import Commanded.Projections.ProjectionAssertions
+
+  alias Commanded.EventStore.RecordedEvent
+  alias Commanded.Projections.Events.AnEvent
+  alias Commanded.Projections.Projection
+  alias Commanded.Projections.Repo
+  alias Commanded.Projections.RuntimeConfigProjector
+
+  setup do
+    start_supervised!(TestApplication)
+    Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+  end
+
+  describe "runtime config projector" do
+    setup do
+      projector1 =
+        start_supervised!(
+          {RuntimeConfigProjector, application: TestApplication, name: "RuntimeProjector1"}
+        )
+
+      projector2 =
+        start_supervised!(
+          {RuntimeConfigProjector, application: TestApplication, name: "RuntimeProjector2"}
+        )
+
+      Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), projector1)
+      Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), projector2)
+
+      [projector1: projector1, projector2: projector2]
+    end
+
+    test "should handle a projected event", %{projector1: projector1} do
+      send_events(projector1, [
+        %RecordedEvent{
+          event_number: 1,
+          event_id: UUID.uuid4(),
+          data: %AnEvent{pid: self()},
+          metadata: %{}
+        }
+      ])
+
+      assert_receive {:project, "AnEvent"}
+
+      assert_projections(Projection, ["AnEvent"])
+      assert last_seen_event("RuntimeProjector1") == 1
+      assert last_seen_event("RuntimeProjector2") == nil
+    end
+  end
+
+  defp send_events(projector, events) do
+    send(projector, {:events, events})
+  end
+end

--- a/test/support/events.ex
+++ b/test/support/events.ex
@@ -1,0 +1,29 @@
+defmodule Commanded.Projections.Events do
+  defmodule AnEvent do
+    defstruct [:pid, name: "AnEvent"]
+  end
+
+  defmodule AnotherEvent do
+    defstruct [:pid, name: "AnotherEvent"]
+  end
+
+  defmodule IgnoredEvent do
+    defstruct [:pid, name: "IgnoredEvent"]
+  end
+
+  defmodule ErrorEvent do
+    defstruct [:pid, name: "ErrorEvent"]
+  end
+
+  defmodule ExceptionEvent do
+    defstruct [:pid, name: "ExceptionEvent"]
+  end
+
+  defmodule InvalidMultiEvent do
+    defstruct [:pid, :name]
+  end
+
+  defmodule SchemaEvent do
+    defstruct [:schema, name: "SchemaEvent"]
+  end
+end

--- a/test/support/projection.ex
+++ b/test/support/projection.ex
@@ -1,0 +1,7 @@
+defmodule Commanded.Projections.Projection do
+  use Ecto.Schema
+
+  schema "projections" do
+    field(:name, :string)
+  end
+end

--- a/test/support/projection_assertions.ex
+++ b/test/support/projection_assertions.ex
@@ -11,12 +11,16 @@ defmodule Commanded.Projections.ProjectionAssertions do
 
   def assert_seen_event(projection_name, expected_last_seen)
       when is_binary(projection_name) and is_integer(expected_last_seen) do
-    assert {:ok, %{rows: [[^expected_last_seen]], num_rows: 1}} =
-             Ecto.Adapters.SQL.query(
-               Repo,
-               "SELECT last_seen_event_number from projection_versions where projection_name = $1",
-               [projection_name]
-             )
+    assert last_seen_event(projection_name) == expected_last_seen
+  end
+
+  def last_seen_event(projection_name) when is_binary(projection_name) do
+    sql = "SELECT last_seen_event_number from projection_versions where projection_name = $1"
+
+    case Ecto.Adapters.SQL.query(Repo, sql, [projection_name]) do
+      {:ok, %{num_rows: 0}} -> nil
+      {:ok, %{rows: [[last_seen]], num_rows: 1}} -> last_seen
+    end
   end
 
   defp pluck(enumerable, field) do

--- a/test/support/runtime_config_projector.ex
+++ b/test/support/runtime_config_projector.ex
@@ -1,0 +1,14 @@
+defmodule Commanded.Projections.RuntimeConfigProjector do
+  use Commanded.Projections.Ecto
+
+  alias Commanded.Projections.Events.AnEvent
+  alias Commanded.Projections.Projection
+
+  project %AnEvent{} = event, fn multi ->
+    %AnEvent{name: name, pid: pid} = event
+
+    send(pid, {:project, name})
+
+    Ecto.Multi.insert(multi, :my_projection, %Projection{name: name})
+  end
+end


### PR DESCRIPTION
Allow the Commanded application and projector name to be specified at runtime, instead of using a compile-time constant. This allows the same projector module to be started multiple times, but each using a unique name and/or Commanded application. 

Using a unique name for a projector, but different Commanded applications, means you can project events from different event stores into a single multi-tenant read model.

### Example

```elixir
defmodule ExampleProjector do
  use Commanded.Projections.Ecto

  project %AnEvent{name: name}, fn multi ->
    Ecto.Multi.insert(multi, :projection, %Projection{name: name})
  end
end
```

Usage:

```elixir
Supervisor.start_link([
  {ExampleProjector, application: App1, name: "App1.Projector"},
  {ExampleProjector, application: App2, name: "App2.Projector"}
], strategy: :one_for_one)
```

Closes #31.
