### PR TITLE
Concurrency issue when updating projection version

### DIFF
--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -27,8 +27,6 @@ defmodule Commanded.Projections.Ecto do
   - [Usage](usage.html)
 
   """
-  alias ErrorProjector.ProjectionVersion
-
   defmacro __using__(opts) do
     opts = opts || []
 


### PR DESCRIPTION
Concurrency issue when updating projection version.

The problem can occur because the existing projection version is fetched before the update transaction. In rare cases we have seen events being executed twice because of this. 

The solution, as implemented in this PR, is to both fetch and update the projection version within the same transaction.