### PR TITLE
Use an UPSERT SQL query to insert or update the projection version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,28 @@
 # Changelog
 
+## Next release
+
+### Enhancements
+
+- Use an UPSERT SQL query to insert or update the projection version ([#52](https://github.com/commanded/commanded-ecto-projections/pull/52)).
+
 ## 1.3.0
+
+### Enhancements
 
 - Fix Elixir 1.14 compilation warnings ([#45](https://github.com/commanded/commanded-ecto-projections/pull/45)).
 
+---
+
 ## 1.2.1
+
+### Enhancements
 
 - Allow exceptions to be rescued by Commanded's event handler ([#37](https://github.com/commanded/commanded-ecto-projections/pull/37)).
 
 ## 1.2.0
+
+### Enhancements
 
 - Support runtime projector names ([#32](https://github.com/commanded/commanded-ecto-projections/pull/32)).
 - Support `schema_prefix/2` function ([#33](https://github.com/commanded/commanded-ecto-projections/pull/33)).

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,5 +13,5 @@ config :commanded_ecto_projections, Commanded.Projections.Repo,
 
 config :ex_unit, capture_log: true
 
-# Print only warnings and errors during test
+# Print only warning and above log messages during tests
 config :logger, :console, level: :warning, format: "[$level] $message\n"

--- a/mix.exs
+++ b/mix.exs
@@ -37,13 +37,13 @@ defmodule Commanded.Projections.Ecto.Mixfile do
       {:postgrex, ">= 0.0.0", only: :test},
 
       # Optional dependencies
-      {:jason, "~> 1.3", optional: true},
+      {:jason, "~> 1.4", optional: true},
 
       # Test & build tooling
-      {:dialyxir, "~> 1.2", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.1", only: :dev, runtime: false},
-      {:mox, "~> 1.0", only: :test}
+      {:mox, "~> 1.1", only: :test}
     ]
   end
 

--- a/test/projections/ecto_projection_test.exs
+++ b/test/projections/ecto_projection_test.exs
@@ -68,6 +68,25 @@ defmodule Commanded.Projections.EctoProjectionTest do
     assert_seen_event("Projector", 3)
   end
 
+  test "should prevent an event being projected more than once" do
+    Projector.handle(%AnEvent{name: "Event1"}, %{handler_name: "Projector", event_number: 1})
+    Projector.handle(%AnEvent{name: "Event2"}, %{handler_name: "Projector", event_number: 2})
+
+    tasks =
+      Enum.map(1..5, fn _index ->
+        Task.async(fn ->
+          Projector.handle(%AnEvent{name: "Event3"}, %{handler_name: "Projector", event_number: 3})
+        end)
+      end)
+
+    results = Task.await_many(tasks)
+
+    assert Enum.uniq(results) == [:ok]
+
+    assert_projections(Projection, ["Event1", "Event2", "Event3"])
+    assert_seen_event("Projector", 3)
+  end
+
   test "should return an error on failure" do
     assert {:error, :failure} ==
              Projector.handle(%ErrorEvent{}, %{handler_name: "Projector", event_number: 1})


### PR DESCRIPTION
To guarantee that an event cannot be projected more than once an "UPSERT" query is now used to INSERT or UPDATE the last seen event in the projection versions table. Using a single SQL statement will guard against concurrent handling of the same event since only one process will be able to successfully update (or insert) the projection version.