### PR TITLE
Fix result typespec of `c:after_update/3`

### DIFF
--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -150,7 +150,7 @@ defmodule Commanded.Projections.Ecto do
 
   """
   @callback after_update(event :: struct, metadata :: map, changes :: Ecto.Multi.changes()) ::
-              :ok | {:error, any}
+              :ok | {:ok, any} | {:error, any}
 
   @doc """
   The optional `schema_prefix/1` callback function defined in a projector is


### PR DESCRIPTION
The `c:Commanded.Event.Handler.handle/2` callback allows returning an `{:ok, state}` tuple. But the typespec of our `c:after_update/3` callback does not include this.